### PR TITLE
Remove static type

### DIFF
--- a/data_describe/backends/compute/_pandas/importance.py
+++ b/data_describe/backends/compute/_pandas/importance.py
@@ -3,11 +3,10 @@ from sklearn.ensemble import RandomForestClassifier
 from sklearn.inspection import permutation_importance
 
 from data_describe.utilities.preprocessing import preprocess
-from data_describe.compat import _DATAFRAME_STATIC_TYPE
 
 
 def compute_importance(
-    data: _DATAFRAME_STATIC_TYPE,
+    data,
     target: str,
     preprocess_func=None,
     estimator=None,


### PR DESCRIPTION
_DATAFRAME_STATIC_TYPE shouldn't be used; the type hint doesn't work when modin (optional) is not installed