### PR TITLE
made data_summary return dataframe (bug 371)

### DIFF
--- a/data_describe/core/summary.py
+++ b/data_describe/core/summary.py
@@ -60,14 +60,14 @@ class SummaryWidget(BaseWidget):
 
 
 def data_summary(data, compute_backend=None):
-    """Summary statistics and data description.
+    """Summary statistics and data description with metrics in rows and original fields as columns.
 
     Args:
         data: The dataframe
         compute_backend: The compute backend.
 
     Returns:
-        The dataframe with metrics in rows
+        SummaryWidget
     """
     return _get_compute_backend(backend=compute_backend, df=data).compute_data_summary(
         data


### PR DESCRIPTION
I modified the data_summary function to return the dataframe of metrics (by calling the show() function on the widget that was previously returned). I also updated the docstring.

As a side note there is a lot of logic involving backends, and the possibility of a user passing their own backend. What I've done assumes that calling show() will return the correct dataframe, regardless of the backend used.